### PR TITLE
Adding CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+
+name: Lint and test
+
+on:
+  push:
+    branches:
+      - main
+      - newMain
+  pull_request:
+    branches:
+      - main
+      - newMain
+  workflow_call: # Usually called from deploy
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  checks: write # for coverallsapp/github-action to create new checks
+  contents: read # for actions/checkout to fetch code
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
Added workflow so that test file runs on push / pull. 

My code is mainly from the [starter workflows repo ](https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml)and the [workflow file from the nodebb repo](https://github.com/CMU-313/nodebb-s25-eagles/blob/newMain/.github/workflows/test.yaml). 
I also don't know if coveralls works with this, but I copied over the coverall stuff from the other yaml file to see if it will.